### PR TITLE
Upgrade Cloud Function runtime from Node.js 20 to 22

### DIFF
--- a/shiftworker-backend/package.json
+++ b/shiftworker-backend/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "deploy": "npm run build && gcloud functions deploy shiftworkerHttp --runtime nodejs20 --trigger-http --allow-unauthenticated",
+    "deploy": "npm run build && gcloud functions deploy shiftworkerHttp --runtime nodejs22 --trigger-http --allow-unauthenticated",
     "build": "tsc"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #7

Changes `--runtime nodejs20` to `--runtime nodejs22` in the deploy script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)