### PR TITLE
Move GCS bucket name to environment variable

### DIFF
--- a/shiftworker-backend/src/fileService.ts
+++ b/shiftworker-backend/src/fileService.ts
@@ -2,17 +2,19 @@ import fs from "fs";
 import crypto from "crypto";
 const { Storage } = require("@google-cloud/storage");
 
+const bucketName = process.env.GCS_BUCKET_NAME;
+if (!bucketName) {
+  throw new Error("Missing required environment variable: GCS_BUCKET_NAME");
+}
+
 export class GCloudFileService implements FileService {
   async writeToStorage(icalAsString: string): Promise<string> {
     const storage = new Storage();
     const id = crypto.randomBytes(16).toString("hex");
     const filePath = `${id}.ical`;
-    await storage
-      .bucket("shiftworker-to-ical-generated-output")
-      .file(filePath)
-      .save(icalAsString);
+    await storage.bucket(bucketName).file(filePath).save(icalAsString);
 
-    return `https://storage.googleapis.com/shiftworker-to-ical-generated-output/${filePath}`;
+    return `https://storage.googleapis.com/${bucketName}/${filePath}`;
   }
 
   writeToTmpFile(input: any): Promise<string> {


### PR DESCRIPTION
Closes #12

Reads bucket name from `GCS_BUCKET_NAME` env var instead of hardcoding it. Throws on startup if the variable is missing.

**`shiftworker-backend/src/fileService.ts`**

## Deploy
Remember to set the env var when deploying:
```bash
gcloud functions deploy shiftworkerHttp \
  --set-env-vars GCS_BUCKET_NAME=shiftworker-to-ical-generated-output \
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)