### PR TITLE
Use user's timezone when parsing shift times from database

### DIFF
--- a/shiftworker-backend/src/core/index.ts
+++ b/shiftworker-backend/src/core/index.ts
@@ -14,7 +14,7 @@ export const exportShiftworkerFileToIcal = async (
   options: ExportShiftworkerFileToIcalOptions
 ): Promise<string> => {
   const repository = await initializeShiftworkerDbRepository(filepath);
-  const service = new ShiftworkerExportService(repository, { debug: false });
+  const service = new ShiftworkerExportService(repository, { debug: false, timezone: options.timezone });
   return service.exportShifts().then((shifts) => {
     const configValidationResult = mapToValidConfig(options);
     if (configValidationResult.ok) {

--- a/shiftworker-backend/src/core/shiftworker/shiftworkerExportService.test.ts
+++ b/shiftworker-backend/src/core/shiftworker/shiftworkerExportService.test.ts
@@ -1,0 +1,71 @@
+import { ShiftworkerExportService } from "./shiftworkerExportService";
+import { ShiftworkerRepository, ShiftDB, ShifttypeDB } from "./db/db";
+
+const makeRepository = (
+  shifts: ShiftDB[],
+  shifttypes: ShifttypeDB[]
+): ShiftworkerRepository => ({
+  getShifts: () => Promise.resolve(shifts),
+  getShifttypes: () => Promise.resolve(shifttypes),
+});
+
+const SHIFT: ShiftDB = {
+  id: "1",
+  shifttype: "day",
+  date: "04-13-2030 00:00:00",
+};
+
+const SHIFTTYPE: ShifttypeDB = {
+  primarykey: "day",
+  start: "07:30:00",
+  end: "15:30:00",
+  description: "Day Shift",
+};
+
+describe("ShiftworkerExportService", () => {
+  describe("Timezone parsing", () => {
+    test("parser skifttider som Oslo-tid når Europe/Oslo er valgt", async () => {
+      const service = new ShiftworkerExportService(
+        makeRepository([SHIFT], [SHIFTTYPE]),
+        { debug: false, timezone: "Europe/Oslo" }
+      );
+      const shifts = await service.exportShifts();
+      expect(shifts[0].start.utcOffset()).toBe(120); // UTC+2 (sommertid i april)
+      expect(shifts[0].start.hour()).toBe(7);
+      expect(shifts[0].start.minute()).toBe(30);
+    });
+
+    test("parser skifttider som New York-tid når America/New_York er valgt", async () => {
+      const service = new ShiftworkerExportService(
+        makeRepository([SHIFT], [SHIFTTYPE]),
+        { debug: false, timezone: "America/New_York" }
+      );
+      const shifts = await service.exportShifts();
+      expect(shifts[0].start.utcOffset()).toBe(-240); // UTC-4 (sommertid i april)
+      expect(shifts[0].start.hour()).toBe(7);
+      expect(shifts[0].start.minute()).toBe(30);
+    });
+
+    test("Oslo- og New York-skift med samme klokkeslett er ulike UTC-tidspunkter", async () => {
+      const osloService = new ShiftworkerExportService(
+        makeRepository([SHIFT], [SHIFTTYPE]),
+        { debug: false, timezone: "Europe/Oslo" }
+      );
+      const nyService = new ShiftworkerExportService(
+        makeRepository([SHIFT], [SHIFTTYPE]),
+        { debug: false, timezone: "America/New_York" }
+      );
+
+      const [osloShifts, nyShifts] = await Promise.all([
+        osloService.exportShifts(),
+        nyService.exportShifts(),
+      ]);
+
+      // 07:30 Oslo (UTC+2) og 07:30 New York (UTC-4) er 6 timer fra hverandre
+      const diffHours =
+        (nyShifts[0].start.valueOf() - osloShifts[0].start.valueOf()) /
+        (1000 * 60 * 60);
+      expect(diffHours).toBe(6);
+    });
+  });
+});

--- a/shiftworker-backend/src/core/shiftworker/shiftworkerExportService.ts
+++ b/shiftworker-backend/src/core/shiftworker/shiftworkerExportService.ts
@@ -19,7 +19,7 @@ export class ShiftworkerExportService {
   async exportShifts(): Promise<Shift[]> {
     const shifts = await this.repository.getShifts();
     const shifttypes = await this.repository.getShifttypes();
-    const mappedShifts = this.mapShifts(shifts, shifttypes).filter((shift) =>
+    const mappedShifts = this.mapShifts(shifts, shifttypes, this.config.timezone).filter((shift) =>
       isAfterYesterday(shift.start.toDate())
     );
 
@@ -30,7 +30,7 @@ export class ShiftworkerExportService {
     return mappedShifts;
   }
 
-  private mapShifts(shifts: ShiftDB[], shifttypes: ShifttypeDB[]): Shift[] {
+  private mapShifts(shifts: ShiftDB[], shifttypes: ShifttypeDB[], timezone: string): Shift[] {
     return shifts.map((shift): Shift => {
       const shifttype = shifttypes.find(
         (type) => type.primarykey === shift.shifttype
@@ -38,7 +38,7 @@ export class ShiftworkerExportService {
       if (!shifttype) {
         throw new Error(`Could not find shifttype for ${shift.shifttype}`);
       }
-      const { start, end } = parseDates(shift, shifttype);
+      const { start, end } = parseDates(shift, shifttype, timezone);
       return {
         start: start,
         end: end,
@@ -66,9 +66,9 @@ export class ShiftworkerExportService {
   }
 }
 
-const parseDates = (shift: ShiftDB, shifttype: ShifttypeDB) => {
-  const shiftStart = parseDate(shift.date, shifttype.start);
-  const shiftEnd = parseDate(shift.date, shifttype.end);
+const parseDates = (shift: ShiftDB, shifttype: ShifttypeDB, timezone: string) => {
+  const shiftStart = parseDate(shift.date, shifttype.start, timezone);
+  const shiftEnd = parseDate(shift.date, shifttype.end, timezone);
   if (shiftEnd.isBefore(shiftStart)) {
     return {
       start: shiftStart,
@@ -82,9 +82,9 @@ const parseDates = (shift: ShiftDB, shifttype: ShifttypeDB) => {
   };
 };
 
-const parseDate = (shiftDateRaw: string, shifttypeStart: string) => {
+const parseDate = (shiftDateRaw: string, shifttypeStart: string, timezone: string) => {
   const rawString = `${shiftDateRaw.split(" ")[0]} ${shifttypeStart}`;
-  return dayjs.tz(rawString, "MM-DD-YYYY HH:mm:ss", "Europe/Oslo");
+  return dayjs.tz(rawString, "MM-DD-YYYY HH:mm:ss", timezone);
 };
 
 export interface Shift {
@@ -95,4 +95,5 @@ export interface Shift {
 
 interface Config {
   debug: boolean;
+  timezone: string;
 }


### PR DESCRIPTION
Closes #15

## Problemet
Shiftworker-databasen lagrer skifttider som lokale klokkeslett (f.eks. `07:30`). Disse ble alltid tolket som `Europe/Oslo`-tid, uavhengig av hva brukeren oppga som tidssone. En bruker i New York med et `07:30`-skift fikk `01:30` i kalenderen sin.

## Fiksen
Timezone-parameteren sendes nå gjennom hele call-chainen ned til `parseDate()`:

```
exportShiftworkerFileToIcal(options.timezone)
  → ShiftworkerExportService(config.timezone)
    → mapShifts(timezone)
      → parseDates(timezone)
        → parseDate(timezone)  // ikke lenger hardkodet "Europe/Oslo"
```

## Tester
Ny testfil `shiftworkerExportService.test.ts` verifiserer at:
- `07:30` med `Europe/Oslo` gir UTC+2-offset
- `07:30` med `America/New_York` gir UTC-4-offset
- De to er 6 timer fra hverandre i UTC (som forventet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)