### PR TITLE
Name the generated calendar instead of showing the URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 out.*
 tmp.txt
+*.ical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Backend (`cd shiftworker-backend`):
 npm test            # jest (ts-jest), matches **/*.test.ts
 npm run build       # tsc — test files are excluded from the build
 npm run deploy      # build + gcloud functions deploy (requires gcloud auth)
-npx ts-node src/localClient.ts <path-to-db-dump>   # run the conversion locally
+npx ts-node src/localClient.ts <path-to-db-dump> [calendar-name]   # run locally
 ```
 
 Frontend (`cd shiftworker-web`):
@@ -64,6 +64,9 @@ layer.
 - Timezone comes from the client (`?timezone=` query param, resolved via
   `Intl.DateTimeFormat().resolvedOptions().timeZone`) and is validated by
   `ValidTimeZone` — never hardcode a zone.
+- The optional `?calendarName=` query param sets `NAME`/`X-WR-CALNAME` in the
+  iCal output and the file name part of the generated URL; it is sanitized by
+  `sanitizeCalendarName` and defaults to `Shiftworker`.
 - Backend logs are single-line JSON with a `severity` and `requestId`; use the
   existing `log()` helper rather than bare `console.log` in the handler.
 - Prefer adding unit tests next to the code (`*.test.ts`) for anything in

--- a/shiftworker-backend/index.ts
+++ b/shiftworker-backend/index.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "@google-cloud/functions-framework";
 import { randomUUID } from "crypto";
 import { ShiftworkerToIcalService } from "./src/shiftworkerToIcalService";
 import { GCloudFileService } from "./src/fileService";
+import { sanitizeCalendarName } from "./src/core/ical/icalWriter";
 
 const functions = require("@google-cloud/functions-framework");
 
@@ -88,7 +89,8 @@ async function handlePost(req: Request): Promise<string> {
   }
   const service = new ShiftworkerToIcalService(new GCloudFileService());
   const timezone = extractTimezoneFromUrlQuery(req);
-  return await service.convert(req.body, { timezone });
+  const calendarName = extractCalendarNameFromUrlQuery(req);
+  return await service.convert(req.body, { timezone, calendarName });
 }
 
 class FileTooLargeError extends Error {
@@ -109,4 +111,12 @@ const extractTimezoneFromUrlQuery = (req: Request): string => {
     throw new TimezoneError("Missing required query parameter: timezone");
   }
   return <string>timezone;
+};
+
+const extractCalendarNameFromUrlQuery = (req: Request): string | undefined => {
+  const calendarName = req.query.calendarName;
+  if (typeof calendarName !== "string") {
+    return undefined;
+  }
+  return sanitizeCalendarName(calendarName);
 };

--- a/shiftworker-backend/readme.md
+++ b/shiftworker-backend/readme.md
@@ -10,11 +10,19 @@ the public URL to the frontend.
 npm install
 npm test                                           # jest
 npm run build                                      # tsc
-npx ts-node src/localClient.ts <path-to-db-dump>    # convert a dump locally
+npx ts-node src/localClient.ts <path-to-db-dump> [calendar-name]   # convert a dump locally
 ```
 
-The local client writes its scratch and output files (`tmp.txt`, `out.tmp`) to
-the working directory; both are git-ignored.
+The local client writes its scratch file (`tmp.txt`) and the generated calendar
+(`<calendar-name>.ical`, defaults to `shiftworker.ical`) to the working
+directory; both are git-ignored.
+
+## Query parameters
+
+| Parameter      | Required | Description                                                                 |
+| -------------- | -------- | --------------------------------------------------------------------------- |
+| `timezone`     | yes      | IANA timezone the shift times are interpreted in, e.g. `Europe/Oslo`.        |
+| `calendarName` | no       | Name calendar apps show for the calendar. Defaults to `Shiftworker`.         |
 
 ## Deploy
 

--- a/shiftworker-backend/src/core/ical/icalWriter.test.ts
+++ b/shiftworker-backend/src/core/ical/icalWriter.test.ts
@@ -2,6 +2,8 @@ import dayjs from "dayjs";
 import {
   convertToIcal,
   convertToVEvent,
+  DEFAULT_CALENDAR_NAME,
+  sanitizeCalendarName,
   ToIcalConfig,
   ValidTimeZone,
 } from "./icalWriter";
@@ -67,6 +69,36 @@ describe("Følger ICAL spesifikasjon", () => {
       expect(convertToIcal(getDefaultInput(), defaultConfig())).toContain(
         "END:VEVENT"
       );
+    });
+
+    test("inkluderer kalendernavn slik at klienter viser noe annet enn urlen", () => {
+      const result = convertToIcal(getDefaultInput(), {
+        ...defaultConfig(),
+        calendarName: "Ingrids vakter",
+      });
+      expect(result).toContain("NAME:Ingrids vakter\n");
+      expect(result).toContain("X-WR-CALNAME:Ingrids vakter\n");
+    });
+
+    test("bruker standardnavn når kalendernavn mangler", () => {
+      const result = convertToIcal(getDefaultInput(), defaultConfig());
+      expect(result).toContain(`X-WR-CALNAME:${DEFAULT_CALENDAR_NAME}\n`);
+    });
+
+    test("bruker standardnavn når kalendernavn er tomt", () => {
+      const result = convertToIcal(getDefaultInput(), {
+        ...defaultConfig(),
+        calendarName: "   ",
+      });
+      expect(result).toContain(`X-WR-CALNAME:${DEFAULT_CALENDAR_NAME}\n`);
+    });
+
+    test("escaper spesialtegn i kalendernavnet", () => {
+      const result = convertToIcal(getDefaultInput(), {
+        ...defaultConfig(),
+        calendarName: "Vakter; kveld, natt",
+      });
+      expect(result).toContain("X-WR-CALNAME:Vakter\\; kveld\\, natt\n");
     });
 
     test("har ingen tomme linjer", () => {
@@ -143,6 +175,25 @@ describe("Følger ICAL spesifikasjon", () => {
         expect(summary).toEqual(`Ingrid: ${input[0].summary}`);
       });
     });
+  });
+});
+
+describe("sanitizeCalendarName", () => {
+  test("fjerner linjeskift og kontrolltegn", () => {
+    expect(sanitizeCalendarName("Mine\nvakter")).toEqual("Mine vakter");
+  });
+
+  test("trimmer og kollapser mellomrom", () => {
+    expect(sanitizeCalendarName("  Mine   vakter  ")).toEqual("Mine vakter");
+  });
+
+  test("kutter navn som er for langt", () => {
+    expect(sanitizeCalendarName("a".repeat(100))).toHaveLength(60);
+  });
+
+  test("returnerer undefined for tomt navn", () => {
+    expect(sanitizeCalendarName("   ")).toBeUndefined();
+    expect(sanitizeCalendarName(undefined)).toBeUndefined();
   });
 });
 

--- a/shiftworker-backend/src/core/ical/icalWriter.ts
+++ b/shiftworker-backend/src/core/ical/icalWriter.ts
@@ -10,16 +10,56 @@ import { Shift } from "../shiftworker/shiftworkerExportService";
 import { failure, Result, success } from "../utils/result";
 import { isValidTimeZone } from "../utils/dateUtil";
 
+export const DEFAULT_CALENDAR_NAME = "Shiftworker";
+const MAX_CALENDAR_NAME_LENGTH = 60;
+
 export const convertToIcal = (
   shifts: Shift[],
   config: ToIcalConfig
 ): string => {
   const events = shifts.map((shift) => convertToVEvent(shift, config));
+  const calendarName = escapeText(
+    sanitizeCalendarName(config.calendarName) ?? DEFAULT_CALENDAR_NAME
+  );
+  // NAME is the standard property (RFC 7986), X-WR-CALNAME the de facto one
+  // that most calendar apps read. Both are emitted so subscribed calendars
+  // show a readable name instead of the URL they were imported from.
   return `BEGIN:VCALENDAR
 PRODID:-//hacksw/handcal//NONSGML v1.0//EN
 VERSION:2.0
+NAME:${calendarName}
+X-WR-CALNAME:${calendarName}
 ${events.join("")}END:VCALENDAR`;
 };
+
+/**
+ * Trims a user supplied calendar name and strips characters that cannot appear
+ * in an iCal property value. Returns undefined when nothing usable is left.
+ */
+export const sanitizeCalendarName = (
+  calendarName?: string
+): string | undefined => {
+  if (!calendarName) {
+    return undefined;
+  }
+  const sanitized = calendarName
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_CALENDAR_NAME_LENGTH)
+    .trim();
+  return sanitized.length > 0 ? sanitized : undefined;
+};
+
+/**
+ * Escapes a TEXT property value according to RFC 5545 section 3.3.11.
+ */
+const escapeText = (value: string): string =>
+  value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
 
 export const convertToVEvent = (shift: Shift, config: ToIcalConfig) => {
   const summary = config?.prefix
@@ -39,6 +79,7 @@ END:VEVENT
 export interface ToIcalConfig {
   prefix?: string;
   timezone: ValidTimeZone;
+  calendarName?: string;
 }
 
 export class ValidTimeZone {

--- a/shiftworker-backend/src/core/index.ts
+++ b/shiftworker-backend/src/core/index.ts
@@ -29,11 +29,15 @@ const mapToValidConfig = (
 ): Result<ToIcalConfig, string> => {
   const result = ValidTimeZone.create(config.timezone);
   if (result.ok) {
-    return success({ timezone: result.value });
+    return success({
+      timezone: result.value,
+      calendarName: config.calendarName,
+    });
   }
   return failure(result.error);
 };
 
 interface ExportShiftworkerFileToIcalOptions {
   timezone: string;
+  calendarName?: string;
 }

--- a/shiftworker-backend/src/fileService.test.ts
+++ b/shiftworker-backend/src/fileService.test.ts
@@ -1,0 +1,22 @@
+import { toFileName } from "./fileService";
+
+describe("toFileName", () => {
+  test("lager en lesbar slug av kalendernavnet", () => {
+    expect(toFileName("Ingrids vakter")).toEqual("ingrids-vakter");
+  });
+
+  test("fjerner aksenter og norske tegn", () => {
+    expect(toFileName("Nattevakt på øya")).toEqual("nattevakt-pa-oya");
+  });
+
+  test("faller tilbake til standardnavn", () => {
+    expect(toFileName(undefined)).toEqual("shiftworker");
+    expect(toFileName("***")).toEqual("shiftworker");
+  });
+
+  test("begrenser lengden uten å ende på bindestrek", () => {
+    const fileName = toFileName("a".repeat(30) + " " + "b".repeat(30));
+    expect(fileName.length).toBeLessThanOrEqual(40);
+    expect(fileName).not.toEndWith("-");
+  });
+});

--- a/shiftworker-backend/src/fileService.ts
+++ b/shiftworker-backend/src/fileService.ts
@@ -2,15 +2,41 @@ import fs from "fs";
 import crypto from "crypto";
 const { Storage } = require("@google-cloud/storage");
 
+const DEFAULT_FILE_NAME = "shiftworker";
+const MAX_FILE_NAME_LENGTH = 40;
+
+/**
+ * Turns a calendar name into a safe, readable file name. The name only affects
+ * the last part of the URL — uniqueness still comes from the random id prefix.
+ */
+export const toFileName = (calendarName?: string): string => {
+  const slug = (calendarName ?? "")
+    .toLowerCase()
+    .replace(/ø/g, "o")
+    .replace(/æ/g, "ae")
+    .replace(/å/g, "a")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_FILE_NAME_LENGTH)
+    .replace(/-+$/g, "");
+  return slug.length > 0 ? slug : DEFAULT_FILE_NAME;
+};
+
 export class GCloudFileService implements FileService {
-  async writeToStorage(icalAsString: string): Promise<string> {
+  async writeToStorage(
+    icalAsString: string,
+    options?: WriteToStorageOptions
+  ): Promise<string> {
     const storage = new Storage();
     const id = crypto.randomBytes(16).toString("hex");
-    const filePath = `${id}.ical`;
+    const filePath = `${id}/${toFileName(options?.calendarName)}.ical`;
     await storage
       .bucket("shiftworker-to-ical-generated-output")
       .file(filePath)
-      .save(icalAsString);
+      .save(icalAsString, { contentType: "text/calendar; charset=utf-8" });
 
     return `https://storage.googleapis.com/shiftworker-to-ical-generated-output/${filePath}`;
   }
@@ -42,8 +68,14 @@ export class LocalFileService implements FileService {
     return this.writeToFile(input, filePath);
   }
 
-  writeToStorage(icalAsString: string): Promise<string> {
-    return this.writeToFile(icalAsString, "out.tmp");
+  writeToStorage(
+    icalAsString: string,
+    options?: WriteToStorageOptions
+  ): Promise<string> {
+    return this.writeToFile(
+      icalAsString,
+      `${toFileName(options?.calendarName)}.ical`
+    );
   }
 
   private writeToFile(input: any, filepath: string): Promise<string> {
@@ -63,5 +95,12 @@ export class LocalFileService implements FileService {
 
 export interface FileService {
   writeToTmpFile: (input: any) => Promise<string>;
-  writeToStorage: (icalAsString: string) => Promise<string>;
+  writeToStorage: (
+    icalAsString: string,
+    options?: WriteToStorageOptions
+  ) => Promise<string>;
+}
+
+export interface WriteToStorageOptions {
+  calendarName?: string;
 }

--- a/shiftworker-backend/src/localClient.ts
+++ b/shiftworker-backend/src/localClient.ts
@@ -2,12 +2,17 @@ import { ShiftworkerToIcalService } from "./shiftworkerToIcalService";
 import { LocalFileService } from "./fileService";
 import * as fs from "fs";
 
-const localClient = async (argument: string): Promise<string> => {
+const localClient = async (
+  argument: string,
+  calendarName?: string
+): Promise<string> => {
   const service = new ShiftworkerToIcalService(new LocalFileService());
   const inputData = fs.readFileSync(argument);
   return await service.convert(inputData, {
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    calendarName,
   });
 };
 
-localClient(process.argv[process.argv.length - 1]);
+const [filepath, calendarName] = process.argv.slice(2);
+localClient(filepath, calendarName);

--- a/shiftworker-backend/src/shiftworkerToIcalService.ts
+++ b/shiftworker-backend/src/shiftworkerToIcalService.ts
@@ -11,14 +11,17 @@ export class ShiftworkerToIcalService {
 
   public async convert(
     inputData: any,
-    options: { timezone: string }
+    options: { timezone: string; calendarName?: string }
   ): Promise<string> {
     const filepath = await this.fileService.writeToTmpFile(inputData);
     try {
       const icalAsString = await exportShiftworkerFileToIcal(filepath, {
         timezone: options.timezone,
+        calendarName: options.calendarName,
       });
-      const outfile = await this.fileService.writeToStorage(icalAsString);
+      const outfile = await this.fileService.writeToStorage(icalAsString, {
+        calendarName: options.calendarName,
+      });
       console.log(
         `✅ ShiftworkerToIcalService successfully completed and written output to '${outfile}'`
       );

--- a/shiftworker-web/src/UploadFilePage.tsx
+++ b/shiftworker-web/src/UploadFilePage.tsx
@@ -10,12 +10,18 @@ import {
   Box,
   Button,
   FormControl,
+  FormHelperText,
+  FormLabel,
   Heading,
+  Input,
   Stack,
   useDisclosure,
 } from "@chakra-ui/react";
 import { LearnMoreModal } from "./LearnMoreModal";
 import { postToBackend } from "./api";
+
+const DEFAULT_CALENDAR_NAME = "Shiftworker";
+const MAX_CALENDAR_NAME_LENGTH = 60;
 
 export const UploadFilePage = ({
   onSuccess,
@@ -24,6 +30,7 @@ export const UploadFilePage = ({
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<unknown | null>(null);
+  const [calendarName, setCalendarName] = useState(DEFAULT_CALENDAR_NAME);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const onFileSelected = (files: FileList) => {
@@ -33,7 +40,7 @@ export const UploadFilePage = ({
     reader.onload = async (e) => {
       const text = e.target?.result;
       try {
-        const result = await postToBackend(text as string);
+        const result = await postToBackend(text as string, calendarName);
         onSuccess({ url: result });
       } catch (e) {
         setError(e);
@@ -73,7 +80,10 @@ export const UploadFilePage = ({
                 </AccordionButton>
               </h2>
               <AccordionPanel pb={4}>
-                <Advanced isOpen={true} />
+                <Advanced
+                  calendarName={calendarName}
+                  onCalendarNameChange={setCalendarName}
+                />
               </AccordionPanel>
             </AccordionItem>
           </Accordion>
@@ -123,14 +133,34 @@ const FileInput = (props: {
   );
 };
 
-const Advanced = ({ isOpen }: { isOpen: boolean }) => {
-  if (!isOpen) {
-    return null;
-  }
+const Advanced = ({
+  calendarName,
+  onCalendarNameChange,
+}: {
+  calendarName: string;
+  onCalendarNameChange: (calendarName: string) => void;
+}) => {
   return (
-    <>
-      <Heading size={"xs"}>Timezone</Heading>
-      <p>{Intl.DateTimeFormat().resolvedOptions().timeZone}</p>
-    </>
+    <Stack spacing={4}>
+      <FormControl>
+        <FormLabel fontSize={"sm"} marginBottom={1}>
+          <Heading size={"xs"}>Calendar name</Heading>
+        </FormLabel>
+        <Input
+          size={"sm"}
+          value={calendarName}
+          maxLength={MAX_CALENDAR_NAME_LENGTH}
+          placeholder={DEFAULT_CALENDAR_NAME}
+          onChange={(e) => onCalendarNameChange(e.target.value)}
+        />
+        <FormHelperText fontSize={"xs"}>
+          The name your calendar app shows for the imported calendar.
+        </FormHelperText>
+      </FormControl>
+      <Box>
+        <Heading size={"xs"}>Timezone</Heading>
+        <p>{Intl.DateTimeFormat().resolvedOptions().timeZone}</p>
+      </Box>
+    </Stack>
   );
 };

--- a/shiftworker-web/src/api.ts
+++ b/shiftworker-web/src/api.ts
@@ -1,9 +1,16 @@
-export const postToBackend = async (payload: string): Promise<string> => {
+export const postToBackend = async (
+  payload: string,
+  calendarName?: string
+): Promise<string> => {
+  const query = new URLSearchParams({
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  });
+  if (calendarName?.trim()) {
+    query.set("calendarName", calendarName.trim());
+  }
   const response = await fetch(
     "https://us-central1-shiftworker-387320.cloudfunctions.net/shiftworkerHttp?" +
-      new URLSearchParams({
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      }),
+      query,
     {
       method: "post",
       body: payload,


### PR DESCRIPTION
Calendar apps that subscribe to the generated URL had no name to show, so Proton Calendar (and others) fell back to displaying the raw storage URL.

## Changes

**Backend**
- `icalWriter` emits `NAME` (RFC 7986) and `X-WR-CALNAME` in the `VCALENDAR`, defaulting to `Shiftworker`. Both are emitted since `X-WR-CALNAME` is the property most clients actually read.
- Property values are escaped per RFC 5545 §3.3.11 (`\`, `;`, `,`, newline).
- New optional `?calendarName=` query parameter, sanitized by `sanitizeCalendarName` (control characters stripped, whitespace collapsed, max 60 characters, empty → default).
- `GCloudFileService` writes to `<random-id>/<slug>.ical` and sets `Content-Type: text/calendar; charset=utf-8`, so clients that derive a name from the URL get something readable as well. Uniqueness still comes from the random id path segment, so URLs stay unguessable.
- `localClient` takes an optional calendar name as its second argument.

**Frontend**
- "Calendar name" input in the Advanced section, prefilled with `Shiftworker`, passed along as `calendarName`.

Example output:

```
BEGIN:VCALENDAR
PRODID:-//hacksw/handcal//NONSGML v1.0//EN
VERSION:2.0
NAME:Ingrids vakter\, høst
X-WR-CALNAME:Ingrids vakter\, høst
...
```

## Testing

- `npm test` in `shiftworker-backend` — 32 passing, including new tests for the calendar name properties, escaping, sanitizing, and file name slugging.
- `npm run build` in both packages.
- Verified the rendered iCal and generated file name for a name containing a comma and Norwegian characters.

Note: existing calendars already imported by users keep their old URL and are unaffected; only newly generated calendars get a name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjpNWgq1goSaG3paUQgKik

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjpNWgq1goSaG3paUQgKik)_